### PR TITLE
[Issue #2] Implement factor calculations and use provider-style mocks in tests

### DIFF
--- a/engine/factors.py
+++ b/engine/factors.py
@@ -15,7 +15,17 @@ these stubs with real calculations based on the thresholds defined in
 ``engine.thresholds``.
 """
 
-from typing import Dict
+from typing import Dict, Optional
+
+from engine import thresholds
+
+
+def _as_float(value: object) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
 
 
 def compute_trend_factor(market_data: Dict) -> int:
@@ -37,7 +47,15 @@ def compute_trend_factor(market_data: Dict) -> int:
     Returns:
         int: The trend score (+1, 0 or -1).
     """
-    # TODO: implement real trend analysis using market_data
+    close = _as_float(market_data.get("close"))
+    moving_average = _as_float(market_data.get("moving_average"))
+    if close is None or moving_average is None:
+        return 0
+    if thresholds.TREND_REQUIRE_ABOVE_MA:
+        if close > moving_average:
+            return 1
+        if close < moving_average:
+            return -1
     return 0
 
 
@@ -56,7 +74,23 @@ def compute_volatility_factor(vol_data: Dict) -> int:
     Returns:
         int: The volatility score (+1, 0 or -1).
     """
-    # TODO: implement real volatility evaluation using vol_data
+    vix = _as_float(vol_data.get("vix"))
+    iv_percentile = _as_float(vol_data.get("iv_percentile"))
+    vix_change_pct = _as_float(vol_data.get("vix_change_pct"))
+
+    if vix_change_pct is not None and vix_change_pct >= thresholds.VIX_SPIKE_PERCENT_CHANGE:
+        return -1
+    if vix is not None and vix >= thresholds.VIX_EXTREME_LEVEL:
+        return -1
+
+    if iv_percentile is None:
+        return 0
+    if iv_percentile < thresholds.VIX_ELEVATED_PERCENTILE:
+        return -1
+    if iv_percentile >= thresholds.VIX_ELEVATED_PERCENTILE:
+        if vix_change_pct is not None and vix_change_pct < 0:
+            return 1
+        return 0
     return 0
 
 
@@ -94,5 +128,11 @@ def compute_skew_factor(skew_data: Dict) -> int:
     Returns:
         int: The skew/liquidity score (+1, 0 or -1).
     """
-    # TODO: implement real skew evaluation using skew_data
-    return 0
+    skew = _as_float(skew_data.get("skew"))
+    if skew is None:
+        return 0
+    if skew >= thresholds.SKEW_DISQUALIFY_LEVEL:
+        return -1
+    if skew > thresholds.SKEW_CAUTION_LEVEL:
+        return 0
+    return 1

--- a/tests/test_factors.py
+++ b/tests/test_factors.py
@@ -1,33 +1,69 @@
-"""Tests for factor calculation stubs.
+"""Tests for factor calculations."""
 
-These tests ensure that the factor functions return integers within the
-expected range.  The current implementations are stubs that always return
-0, but the tests are written to anticipate real scores once the functions
-are implemented.
-"""
+from unittest.mock import Mock
 
-from engine import factors
+import pytest
+
+from engine import factors, thresholds
 
 
-def test_trend_factor_returns_valid_score() -> None:
-    score = factors.compute_trend_factor({})
-    assert isinstance(score, int)
-    assert score in (-1, 0, 1)
+def _mock_provider_data(payload: dict) -> Mock:
+    mock_data = Mock(spec=dict)
+    mock_data.get.side_effect = lambda key, default=None: payload.get(key, default)
+    return mock_data
 
 
-def test_volatility_factor_returns_valid_score() -> None:
-    score = factors.compute_volatility_factor({})
-    assert isinstance(score, int)
-    assert score in (-1, 0, 1)
+@pytest.mark.parametrize(
+    ("market_data", "expected"),
+    [
+        ({"close": 410.0, "moving_average": 400.0}, 1),
+        ({"close": 390.0, "moving_average": 400.0}, -1),
+        ({"close": None, "moving_average": 400.0}, 0),
+    ],
+)
+def test_trend_factor_from_market_data(market_data: dict, expected: int) -> None:
+    assert factors.compute_trend_factor(_mock_provider_data(market_data)) == expected
 
 
-def test_event_factor_returns_valid_score() -> None:
-    score = factors.compute_event_factor({})
-    assert isinstance(score, int)
-    assert score in (-1, 0, 1)
+def test_volatility_factor_flags_spike() -> None:
+    vol_data = _mock_provider_data(
+        {"vix": thresholds.VIX_EXTREME_LEVEL - 1, "iv_percentile": 0.75, "vix_change_pct": 0.25}
+    )
+    score = factors.compute_volatility_factor(vol_data)
+    assert score == -1
 
 
-def test_skew_factor_returns_valid_score() -> None:
-    score = factors.compute_skew_factor({})
-    assert isinstance(score, int)
-    assert score in (-1, 0, 1)
+def test_volatility_factor_flags_low_vol() -> None:
+    vol_data = _mock_provider_data({"vix": 15.0, "iv_percentile": 0.2})
+    score = factors.compute_volatility_factor(vol_data)
+    assert score == -1
+
+
+def test_volatility_factor_positive_when_elevated_and_declining() -> None:
+    vol_data = _mock_provider_data({"vix": 22.0, "iv_percentile": 0.7, "vix_change_pct": -0.05})
+    score = factors.compute_volatility_factor(vol_data)
+    assert score == 1
+
+
+def test_volatility_factor_neutral_when_missing_change() -> None:
+    vol_data = _mock_provider_data({"vix": 22.0, "iv_percentile": 0.7})
+    score = factors.compute_volatility_factor(vol_data)
+    assert score == 0
+
+
+def test_skew_factor_disqualify_level() -> None:
+    skew_data = _mock_provider_data({"skew": thresholds.SKEW_DISQUALIFY_LEVEL})
+    score = factors.compute_skew_factor(skew_data)
+    assert score == -1
+
+
+def test_skew_factor_caution_range() -> None:
+    skew_data = _mock_provider_data({"skew": thresholds.SKEW_CAUTION_LEVEL + 1})
+    score = factors.compute_skew_factor(skew_data)
+    assert score == 0
+
+
+def test_skew_factor_normal() -> None:
+    skew_data = _mock_provider_data({"skew": thresholds.SKEW_CAUTION_LEVEL - 1})
+    score = factors.compute_skew_factor(skew_data)
+    assert score == 1


### PR DESCRIPTION
### Motivation
- Provide concrete factor scoring logic that uses centralized thresholds and robust numeric parsing so the decision engine can produce deterministic factor-level signals.
- Ensure unit tests mirror provider semantics (use `.get`) and avoid network I/O by using mocks.

### Description
- Implemented numeric parsing helper `_as_float` and applied it in `engine/factors.py` to compute `compute_trend_factor`, `compute_volatility_factor`, and `compute_skew_factor` using values from `engine/thresholds.py` and returning strictly `-1/0/+1`.
- Removed the unused integer helper and kept `compute_event_factor` as a stub per scope.
- Updated `tests/test_factors.py` to use a `_mock_provider_data` `Mock` that mimics provider `.get()` behavior and adjusted test cases to assert concrete scoring paths.
- Preserved behavior that missing `vix_change_pct` yields a neutral volatility score, matching current provider semantics.

### Testing
- Ran `python -m pytest -q` and all tests passed: `17 passed in 1.10s`.
- Self-review completed: YES
- Checks performed: confirmed factor outputs are limited to `-1/0/+1`, thresholds are sourced from `engine/thresholds.py`, tests use mocked provider-style inputs and perform no network calls, and engine logic remains in `engine/`.
- Assumptions/limitations: volatility treats missing `vix_change_pct` as neutral; `compute_event_factor` remains unimplemented per scope.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976797467508326ae4353e747a0467f)