### PR TITLE
[Issue #12] Add earnings event risk provider and disqualifier coverage

### DIFF
--- a/data/calendar/top10_earnings.json
+++ b/data/calendar/top10_earnings.json
@@ -1,0 +1,42 @@
+[
+  {
+    "date": "2026-03-12",
+    "description": "Adobe earnings"
+  },
+  {
+    "date": "2026-04-23",
+    "description": "Alphabet earnings"
+  },
+  {
+    "date": "2026-04-24",
+    "description": "Microsoft earnings"
+  },
+  {
+    "date": "2026-04-30",
+    "description": "Apple earnings"
+  },
+  {
+    "date": "2026-04-30",
+    "description": "Amazon earnings"
+  },
+  {
+    "date": "2026-05-01",
+    "description": "Meta earnings"
+  },
+  {
+    "date": "2026-05-13",
+    "description": "NVIDIA earnings"
+  },
+  {
+    "date": "2026-05-20",
+    "description": "Home Depot earnings"
+  },
+  {
+    "date": "2026-05-21",
+    "description": "Walmart earnings"
+  },
+  {
+    "date": "2026-05-28",
+    "description": "Costco earnings"
+  }
+]

--- a/data/providers/earnings_events.py
+++ b/data/providers/earnings_events.py
@@ -1,25 +1,89 @@
-"""Earnings events provider stub.
+"""Earnings events provider backed by a local JSON calendar."""
 
-This module provides functions to determine when major S&P 500 constituents
-report earnings.  In a real implementation it would query an earnings
-calendar API or scrape dates for the largest companies (e.g. Apple,
-Microsoft).  For v0.1 it returns placeholders.
-"""
+from __future__ import annotations
 
-from typing import Dict, Optional
+import json
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Dict, Optional, Tuple, TypedDict
 
 
-def get_upcoming_earnings_events() -> Dict[str, Optional[int]]:
-    """Return a dictionary describing upcoming earnings events.
+class EarningsEventResult(TypedDict):
+    days_until_next: Optional[int]
+    description: Optional[str]
 
-    The returned dictionary may include:
 
-    - ``days_until_next``: The number of days until the next major earnings
-      release among the top S&P 500 constituents.  ``None`` if unknown.
-    - ``description``: A short description (e.g. "Apple earnings").  ``None``
-      if there are no imminent earnings.
+CALENDAR_PATH = (
+    Path(__file__).resolve().parents[1] / "calendar" / "top10_earnings.json"
+)
 
-    Returns:
-        Dict[str, Optional[int]]: A dictionary with placeholder values.
+
+def _trading_days_until(start: date, end: date) -> int:
+    """Count weekday trading days from ``start`` to ``end``.
+
+    A same-day event returns ``0``. Weekend days are excluded.
     """
-    return {"days_until_next": None, "description": None}
+    if end <= start:
+        return 0
+
+    days = 0
+    current = start
+    while current < end:
+        current += timedelta(days=1)
+        if current.weekday() < 5:
+            days += 1
+    return days
+
+
+def _parse_event(raw_event: Dict[str, object]) -> Optional[Tuple[date, str]]:
+    event_date_raw = raw_event.get("date")
+    description_raw = raw_event.get("description")
+
+    if not isinstance(event_date_raw, str) or not isinstance(description_raw, str):
+        return None
+
+    description = description_raw.strip()
+    if not description:
+        return None
+
+    try:
+        event_date = datetime.strptime(event_date_raw, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+    return event_date, description
+
+
+def get_upcoming_earnings_events(today: Optional[date] = None) -> EarningsEventResult:
+    """Return the next major earnings event as ``{days_until_next, description}``."""
+    current_day = today or date.today()
+
+    try:
+        with CALENDAR_PATH.open("r", encoding="utf-8") as handle:
+            raw_events = json.load(handle)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {"days_until_next": None, "description": None}
+
+    if not isinstance(raw_events, list):
+        return {"days_until_next": None, "description": None}
+
+    upcoming: list[Tuple[int, str]] = []
+    for raw_event in raw_events:
+        if not isinstance(raw_event, dict):
+            continue
+
+        parsed = _parse_event(raw_event)
+        if parsed is None:
+            continue
+
+        event_date, description = parsed
+        if event_date < current_day:
+            continue
+
+        upcoming.append((_trading_days_until(current_day, event_date), description))
+
+    if not upcoming:
+        return {"days_until_next": None, "description": None}
+
+    days_until_next, description = min(upcoming, key=lambda event: event[0])
+    return {"days_until_next": days_until_next, "description": description}

--- a/engine/decision.py
+++ b/engine/decision.py
@@ -84,15 +84,18 @@ def make_decision(data: Dict) -> DecisionResult:
     }
     missing_any = any(missing_flags.values())
 
+    earnings_event_imminent = (
+        earnings_days is not None
+        and earnings_days <= thresholds.EARNINGS_EVENT_WINDOW_DAYS
+    )
+
     disqualifiers = {
         "macro_event_imminent": (
             macro_days is not None
             and macro_days <= thresholds.MACRO_EVENT_WINDOW_DAYS
         ),
-        "earnings_event_imminent": (
-            earnings_days is not None
-            and earnings_days <= thresholds.EARNINGS_EVENT_WINDOW_DAYS
-        ),
+        # Hard disqualifier per Decision Spec: earnings <= 1 trading day => WAIT.
+        "earnings_event_imminent": earnings_event_imminent,
         "downtrend": close is not None
         and moving_average is not None
         and close < moving_average,

--- a/tests/test_data_providers.py
+++ b/tests/test_data_providers.py
@@ -231,6 +231,39 @@ def test_get_upcoming_earnings_events_handles_invalid_json(monkeypatch, tmp_path
     assert result == {"days_until_next": None, "description": None}
 
 
+def test_get_upcoming_earnings_events_handles_non_list_payload(
+    monkeypatch, tmp_path
+) -> None:
+    calendar_path = tmp_path / "top10_earnings.json"
+    calendar_path.write_text(json.dumps({"date": "2024-01-15"}), encoding="utf-8")
+    monkeypatch.setattr(earnings_events, "CALENDAR_PATH", calendar_path)
+
+    result = earnings_events.get_upcoming_earnings_events(
+        today=datetime(2024, 1, 1).date()
+    )
+
+    assert result == {"days_until_next": None, "description": None}
+
+
+def test_get_upcoming_earnings_events_ignores_invalid_rows(
+    monkeypatch, tmp_path
+) -> None:
+    calendar = [
+        {"date": "not-a-date", "description": "Bad date"},
+        {"date": "2024-01-15", "description": "   "},
+        {"date": "2024-01-16", "description": "NVIDIA earnings"},
+    ]
+    calendar_path = tmp_path / "top10_earnings.json"
+    calendar_path.write_text(json.dumps(calendar), encoding="utf-8")
+    monkeypatch.setattr(earnings_events, "CALENDAR_PATH", calendar_path)
+
+    result = earnings_events.get_upcoming_earnings_events(
+        today=datetime(2024, 1, 12).date()
+    )
+
+    assert result == {"days_until_next": 2, "description": "NVIDIA earnings"}
+
+
 def test_get_upcoming_earnings_events_returns_none_when_no_upcoming_events(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/test_data_providers.py
+++ b/tests/test_data_providers.py
@@ -8,7 +8,7 @@ from typing import Dict
 
 import pandas as pd
 
-from data.providers import macro_events, market_data, skew_data, vol_data
+from data.providers import earnings_events, macro_events, market_data, skew_data, vol_data
 
 
 def _build_history(rows: int) -> pd.DataFrame:
@@ -187,5 +187,60 @@ def test_get_upcoming_macro_events_returns_none_when_no_upcoming_events(
     monkeypatch.setattr(macro_events, "CALENDAR_PATH", calendar_path)
 
     result = macro_events.get_upcoming_macro_events(today=datetime(2024, 1, 1).date())
+
+    assert result == {"days_until_next": None, "description": None}
+
+
+def test_get_upcoming_earnings_events_returns_nearest_trading_day_event(
+    monkeypatch, tmp_path
+) -> None:
+    calendar = [
+        {"date": "2024-01-15", "description": "Goldman Sachs earnings"},
+        {"date": "2024-01-16", "description": "Morgan Stanley earnings"},
+    ]
+    calendar_path = tmp_path / "top10_earnings.json"
+    calendar_path.write_text(json.dumps(calendar), encoding="utf-8")
+    monkeypatch.setattr(earnings_events, "CALENDAR_PATH", calendar_path)
+
+    result = earnings_events.get_upcoming_earnings_events(
+        today=datetime(2024, 1, 12).date()
+    )
+
+    assert result == {"days_until_next": 1, "description": "Goldman Sachs earnings"}
+
+
+def test_get_upcoming_earnings_events_handles_missing_or_invalid_file(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(earnings_events, "CALENDAR_PATH", tmp_path / "does-not-exist.json")
+
+    result = earnings_events.get_upcoming_earnings_events(
+        today=datetime(2024, 1, 1).date()
+    )
+
+    assert result == {"days_until_next": None, "description": None}
+
+
+def test_get_upcoming_earnings_events_handles_invalid_json(monkeypatch, tmp_path) -> None:
+    calendar_path = tmp_path / "top10_earnings.json"
+    calendar_path.write_text("{invalid-json", encoding="utf-8")
+    monkeypatch.setattr(earnings_events, "CALENDAR_PATH", calendar_path)
+
+    result = earnings_events.get_upcoming_earnings_events(today=datetime(2024, 1, 1).date())
+
+    assert result == {"days_until_next": None, "description": None}
+
+
+def test_get_upcoming_earnings_events_returns_none_when_no_upcoming_events(
+    monkeypatch, tmp_path
+) -> None:
+    calendar = [{"date": "2023-12-01", "description": "Old earnings"}]
+    calendar_path = tmp_path / "top10_earnings.json"
+    calendar_path.write_text(json.dumps(calendar), encoding="utf-8")
+    monkeypatch.setattr(earnings_events, "CALENDAR_PATH", calendar_path)
+
+    result = earnings_events.get_upcoming_earnings_events(
+        today=datetime(2024, 1, 1).date()
+    )
 
     assert result == {"days_until_next": None, "description": None}

--- a/tests/test_decision.py
+++ b/tests/test_decision.py
@@ -49,6 +49,23 @@ def test_wait_on_earnings_disqualifier() -> None:
     assert any("earnings" in reason.lower() for reason in result.reasons)
 
 
+
+
+def test_wait_on_same_day_earnings_disqualifier() -> None:
+    data = _base_data()
+    data["events"]["earnings"]["days_until_next"] = 0
+    result = make_decision(data)
+    assert result.decision == "WAIT"
+    assert any("earnings" in reason.lower() for reason in result.reasons)
+
+
+def test_enter_when_earnings_more_than_one_day_away() -> None:
+    data = _base_data()
+    data["events"]["earnings"]["days_until_next"] = 2
+    data["events"]["macro"]["days_until_next"] = 10
+    result = make_decision(data)
+    assert result.decision == "ENTER"
+
 def test_wait_on_downtrend_disqualifier() -> None:
     data = _base_data()
     data["market"]["close"] = 4800.0


### PR DESCRIPTION
### Motivation
- Implement the earnings event risk disqualifier from the decision spec so major-company earnings within the next trading day force a `WAIT` decision.
- Provide a local, testable earnings calendar and a provider that computes trading days until the next event without relying on network APIs.
- Ensure the engine uses the provider output as a hard disqualifier while keeping existing factor logic and output contract unchanged.

### Description
- Added a local calendar file `data/calendar/top10_earnings.json` containing top-company earnings dates used by the v0.1 event-risk flow.
- Implemented `data/providers/earnings_events.py` to safely read the local JSON, validate entries, compute weekday-only trading days until the next event, and return `{"days_until_next", "description"}` with `None` fallbacks on errors.
- Wired earnings risk into `engine/decision.py` as an explicit hard disqualifier named `earnings_event_imminent` that forces `WAIT` when `earnings_days <= thresholds.EARNINGS_EVENT_WINDOW_DAYS`.
- Added unit tests in `tests/test_data_providers.py` for the earnings provider (nearest-event selection, missing file, invalid JSON, no upcoming events) and extended `tests/test_decision.py` with edge-case tests verifying earnings disqualification at 0/1 days and non-disqualification at 2 days.

### Testing
- Ran the project quality gate with `python -m pytest -q` which passed: `36 passed`.
- Self-review completed: YES
- Self-review checks performed: output contract preserved (`ENTER`/`WAIT` with bullet reasons only); business logic remains in `engine/` and data access in `data/providers/`; provider error paths return safe `None` values and do not raise; tests remain network-free and use local files/mocks.
- Tests were run with the exact command: `python -m pytest -q`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a956b7d588326b5a4d47ec57adc2d)